### PR TITLE
Allow flexible g and w

### DIFF
--- a/deeprecsys/reweight.py
+++ b/deeprecsys/reweight.py
@@ -333,9 +333,9 @@ class ReWeightLearnerV2:
         elif isinstance(f, SeqModelMixin):
             self.recom_model = recommender.DeepRecommender(user_num, item_num, self.f)
 
-        if isinstance(f, SparseModelMixin):
+        if isinstance(w, SparseModelMixin):
             self.rel_model = recommender.ClassRecommender(user_num, item_num, self.w)
-        elif isinstance(f, SeqModelMixin):
+        elif isinstance(w, SeqModelMixin):
             self.rel_model = recommender.DeepRecommender(user_num, item_num, self.w)
 
     def obj_func(self, f_prob, w_prob, g_score, f_recom_score, labels):
@@ -423,7 +423,7 @@ class ReWeightLearnerV2:
 
         counter = LoopCounter([(OptimizationStep.ARG_MIN_F, f_count),
                                (OptimizationStep.ARG_MIN_W, w_count),
-                               (OptimizationStep.ARG_MAX_G, g_count),])
+                               (OptimizationStep.ARG_MAX_G, g_count), ])
 
         loop_manager = LoopManager(cache)
 
@@ -432,7 +432,6 @@ class ReWeightLearnerV2:
 
         iter_ = 0
         for current_epoch in range(epoch):
-            print(len(f_data))
             for _ in range(len(f_data)):
                 for step in counter:
                     obs = loop_manager.get_data(step)

--- a/validate.sh
+++ b/validate.sh
@@ -1,20 +1,17 @@
 # Test attention implementation, this setting == train attention model directly
-run_reweight_v2.py --model seq --cuda_idx 0 --lambda_ 0 --w_lower_bound 1.0 --g_step 0 --w_step 0
+python run_reweight_v2.py --model seq --cuda_idx 0 --lambda_ 0 --w_lower_bound 1.0 --g_step 0 --w_step 0
 #expect relevance score
 #INFO:deeprecsys.eval:Full empirical relevance score: 0.015552980132450437
 
-
-# Test the reweight training using attention
-run_reweight_v2.py --model seq --cuda_idx 0 --lambda_ 1 --w_lower_bound 1.0 --g_step 1 --w_step 1
-#INFO:root:biased eval for SVD model on test
-#INFO:deeprecsys.eval:Full empirical relevance score: 0.01585596026490078
-#INFO:root:------Reweight and rebalance model ------
-#DEBUG:deeprecsys.data:Build windowed data
-#DEBUG:deeprecsys.data:Build windowed data
-#DEBUG:deeprecsys.data:Build windowed data
-#4825
-#INFO:deeprecsys.eval:Full empirical relevance score: 0.015360927152317965
-#4825
-#INFO:deeprecsys.eval:Full empirical relevance score: 0.01661589403973525
-#4825
+# Test the reweight training using attention with bound
+python run_reweight_v2.py --model seq --cuda_idx 0 --lambda_ 1 --w_lower_bound 1.0 --g_step 1 --w_step 1
 #INFO:deeprecsys.eval:Full empirical relevance score: 0.016677152317880944
+
+# Use different baseclass for w and g
+python run_reweight_v2.py --model seq --cuda_idx 0 --lambda_ 1 --w_lower_bound 0.1 --g_step 1 --w_step 1 --w_model mlp --g_model mlp
+
+# Use attention model for g and w shared item embedding from f
+python run_reweight_v2.py --model seq --cuda_idx 0 --lambda_ 1 --w_lower_bound 0.1 --g_step 1 --w_step 1 --share_f_embed
+
+# Use mf model for g and w shared item embedding from f
+python run_reweight_v2.py --model mf --cuda_idx 0 --lambda_ 1 --w_lower_bound 0.1 --g_step 1 --w_step 1 --share_f_embed


### PR DESCRIPTION
1. Allow g and w to be different from f.

2. Allow g and w to use embeddings from f.
Example: 

`python run_reweight_v2.py --model seq --cuda_idx 0 --lambda_ 1 --w_lower_bound 0.1 --g_step 1 --w_step 1 --share_f_embed`